### PR TITLE
autodetect username

### DIFF
--- a/data_source_ssh_tunnel.go
+++ b/data_source_ssh_tunnel.go
@@ -19,7 +19,7 @@ func dataSourceSSHTunnel() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSSHTunnelRead,
 		Schema: map[string]*schema.Schema{
-			"username": &schema.Schema{
+			"user": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The username",
@@ -88,14 +88,13 @@ func readPrivateKey(pk string) (ssh.AuthMethod, error) {
 }
 
 func dataSourceSSHTunnelRead(d *schema.ResourceData, meta interface{}) error {
-	username := d.Get("username").(string)
+	username := d.Get("user").(string)
 	if username == "" {
 		currentUser, err := user.Current()
 		if err != nil {
 			panic(err)
 		}
 		username = currentUser.Username
-
 	}
 	host := d.Get("host").(string)
 	privateKey := d.Get("private_key").(string)

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 provider "ssh" {}
 
 data "ssh_tunnel" "consul" {
-  user            = "stefan"
+  username        = "stefan" //Optional if not set current user will be used
   host            = "bastion.example.com"
   private_key     = "${file(pathexpand("~/.ssh/id_rsa"))}"
   ssh_agent       = false // by default, SSH agent authentication is attempted if the SSH_AUTH_SOCK environment variable is set

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 provider "ssh" {}
 
 data "ssh_tunnel" "consul" {
-  username        = "stefan" //Optional if not set current user will be used
+  user            = "stefan" // Optional. If not set, your local user's username will be used.
   host            = "bastion.example.com"
   private_key     = "${file(pathexpand("~/.ssh/id_rsa"))}"
   ssh_agent       = false // by default, SSH agent authentication is attempted if the SSH_AUTH_SOCK environment variable is set

--- a/terraform-open-ssh-tunnels/main.go
+++ b/terraform-open-ssh-tunnels/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/user"
 	"sync"
 
 	"github.com/hashicorp/terraform/terraform"
@@ -60,7 +61,15 @@ func main() {
 		for _, r := range m.Resources {
 			if r.Type == "ssh_tunnel" {
 				d := r.Primary.Attributes
-				user := d["user"]
+				username := d["username"]
+				if username == "" {
+					currentUser, err := user.Current()
+					if err != nil {
+						panic(err)
+					}
+					username = currentUser.Username
+
+				}
 				host := d["host"]
 				privateKey := d["private_key"]
 				localAddress := d["local_address"]
@@ -73,7 +82,7 @@ func main() {
 					panic(err)
 				}
 				sshConf := &ssh.ClientConfig{
-					User:            user,
+					User:            username,
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 					Auth:            []ssh.AuthMethod{pubKeyAuth},
 				}


### PR DESCRIPTION
Hi Stefan, following pull request proposed for team collaborations on the same TF codebase in situations where each team member has own user on the bastion host.
I automatically use the current user as ssh user if username not specified, to not change the TF code for each individual user.