### PR TITLE
Add notes/links explaining non-support for terraform >= 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This provider enables SSH port forwarding in Terraform. It is intended as a
 bandaid [until it is supported in Terraform itself](https://github.com/hashicorp/terraform/issues/8367).
 
-*This provider does not support Terraform v0.12 yet. There were some changes made that makes the upgrade non-trivial.*
+*This provider only supports terraform versions `<= 0.11`. It is not compatible with Terraform versions 0.12 and above.*
 
 #### Example
 
@@ -38,6 +38,10 @@ Note that there is a gotcha when trying to apply a generated plan output file (s
 As a workaround, before you apply, run the companion program `terraform-open-ssh-tunnels` on the plan file first in order to reopen the SSH tunnels. [Download from the releases.](https://github.com/stefansundin/terraform-provider-ssh/releases/latest)
 
 Because of [this commit](https://github.com/stefansundin/terraform-provider-ssh/commit/37fa9835b75fde095c863fca89e2f28a0169919d), only the SSH agent is currently supported in this program. Let me know if you can think of a good fix for this.
+
+#### terraform 0.12
+
+This provider relies on a workaround to keep SSH connections open until `terraform` is ready to exit. As of terraform 0.12, provider plugins run in their own process per instance and are destroyed as soon as their resource and data source updates are finished. This provider cannot be updated to add support for Terraform 0.12 and later. For more information, read the [explanation from the Terraform core team](https://discuss.hashicorp.com/t/provider-plugins-that-live-for-the-duration-of-a-terraform-run/2262/2). 
 
 #### TODO
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This provider enables SSH port forwarding in Terraform. It is intended as a
 bandaid [until it is supported in Terraform itself](https://github.com/hashicorp/terraform/issues/8367).
 
-*This provider only supports terraform versions `<= 0.11`. It is not compatible with Terraform versions 0.12 and above.*
+*This provider only supports terraform versions `<= 0.11`. It is not compatible with [ Terraform versions 0.12 and above](#terraform-012).*
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This provider enables SSH port forwarding in Terraform. It is intended as a
 bandaid [until it is supported in Terraform itself](https://github.com/hashicorp/terraform/issues/8367).
 
-*This provider only supports terraform versions `<= 0.11`. It is not compatible with [ Terraform versions 0.12 and above](#terraform-012).*
+*This provider only supports terraform versions `<= 0.11`. It is not compatible with [Terraform versions 0.12 and above](#terraform-012).*
 
 #### Example
 


### PR DESCRIPTION
Adds a link to the HashiCorp forum post where Martin explains that this provider isn’t readily workable with terraform 0.12. Emphasizes that 0.12 support almost certainly won’t come to this plugin.

Closes #11 